### PR TITLE
Add function specificity to AST output

### DIFF
--- a/packages/react-components/token-analyzer-preview/library/analysis-link.json
+++ b/packages/react-components/token-analyzer-preview/library/analysis-link.json
@@ -2,32 +2,59 @@
   "library/src/components/Link/useLinkStyles.styles.ts": {
     "styles": {
       "useStyles": {
+        "focusIndicator": {
+          "tokens": [],
+          "nested": {
+            "&[data-fui-focus-visible]": {
+              "tokens": [
+                {
+                  "property": "textDecorationColor",
+                  "token": "tokens.colorStrokeFocus2",
+                  "path": []
+                }
+              ]
+            }
+          },
+          "assignedVariables": [
+            "styles"
+          ]
+        },
         "root": {
           "tokens": [
             {
               "property": "color",
               "token": "tokens.colorBrandForegroundLink",
-              "path": ["color"]
+              "path": [
+                "color"
+              ]
             },
             {
               "property": "fontFamily",
               "token": "tokens.fontFamilyBase",
-              "path": ["fontFamily"]
+              "path": [
+                "fontFamily"
+              ]
             },
             {
               "property": "fontSize",
               "token": "tokens.fontSizeBase300",
-              "path": ["fontSize"]
+              "path": [
+                "fontSize"
+              ]
             },
             {
               "property": "fontWeight",
               "token": "tokens.fontWeightRegular",
-              "path": ["fontWeight"]
+              "path": [
+                "fontWeight"
+              ]
             },
             {
               "property": "textDecorationThickness",
               "token": "tokens.strokeWidthThin",
-              "path": ["textDecorationThickness"]
+              "path": [
+                "textDecorationThickness"
+              ]
             }
           ],
           "nested": {
@@ -50,14 +77,18 @@
               ]
             }
           },
-          "assignedVariables": ["styles"]
+          "assignedVariables": [
+            "styles"
+          ]
         },
         "subtle": {
           "tokens": [
             {
               "property": "color",
               "token": "tokens.colorNeutralForeground2",
-              "path": ["color"]
+              "path": [
+                "color"
+              ]
             }
           ],
           "nested": {
@@ -80,14 +111,18 @@
               ]
             }
           },
-          "assignedVariables": ["styles"]
+          "assignedVariables": [
+            "styles"
+          ]
         },
         "disabled": {
           "tokens": [
             {
               "property": "color",
               "token": "tokens.colorNeutralForegroundDisabled",
-              "path": ["color"]
+              "path": [
+                "color"
+              ]
             }
           ],
           "nested": {
@@ -110,14 +145,18 @@
               ]
             }
           },
-          "assignedVariables": ["styles"]
+          "assignedVariables": [
+            "styles"
+          ]
         },
         "inverted": {
           "tokens": [
             {
               "property": "color",
               "token": "tokens.colorBrandForegroundInverted",
-              "path": ["color"]
+              "path": [
+                "color"
+              ]
             }
           ],
           "nested": {
@@ -140,7 +179,9 @@
               ]
             }
           },
-          "assignedVariables": ["styles"]
+          "assignedVariables": [
+            "styles"
+          ]
         }
       }
     },
@@ -163,27 +204,39 @@
           "slotName": "root"
         },
         "styles.href": {
-          "conditions": ["root.as === 'a' && root.href"],
+          "conditions": [
+            "root.as === 'a' && root.href"
+          ],
           "slotName": "root"
         },
         "styles.button": {
-          "conditions": ["root.as === 'button'"],
+          "conditions": [
+            "root.as === 'button'"
+          ],
           "slotName": "root"
         },
         "styles.subtle": {
-          "conditions": ["appearance === 'subtle'"],
+          "conditions": [
+            "appearance === 'subtle'"
+          ],
           "slotName": "root"
         },
         "styles.inverted": {
-          "conditions": ["backgroundAppearance === 'inverted'"],
+          "conditions": [
+            "backgroundAppearance === 'inverted'"
+          ],
           "slotName": "root"
         },
         "styles.inline": {
-          "conditions": ["inline"],
+          "conditions": [
+            "inline"
+          ],
           "slotName": "root"
         },
         "styles.disabled": {
-          "conditions": ["disabled"],
+          "conditions": [
+            "disabled"
+          ],
           "slotName": "root"
         }
       }

--- a/packages/react-components/token-analyzer-preview/library/analysis-link.json
+++ b/packages/react-components/token-analyzer-preview/library/analysis-link.json
@@ -5,7 +5,7 @@
         "focusIndicator": {
           "tokens": [],
           "nested": {
-            "&[data-fui-focus-visible]": {
+            ":focus": {
               "tokens": [
                 {
                   "property": "textDecorationColor",

--- a/packages/react-components/token-analyzer-preview/library/analysis.json
+++ b/packages/react-components/token-analyzer-preview/library/analysis.json
@@ -621,7 +621,7 @@
         "circular": {
           "tokens": [],
           "nested": {
-            "&[data-fui-focus-visible]": {
+            ":focus": {
               "tokens": [
                 {
                   "property": "borderRadius",
@@ -638,7 +638,7 @@
         "square": {
           "tokens": [],
           "nested": {
-            "&[data-fui-focus-visible]": {
+            ":focus": {
               "tokens": [
                 {
                   "property": "borderRadius",
@@ -655,7 +655,7 @@
         "small": {
           "tokens": [],
           "nested": {
-            "&[data-fui-focus-visible]": {
+            ":focus": {
               "tokens": [
                 {
                   "property": "borderRadius",
@@ -672,7 +672,7 @@
         "large": {
           "tokens": [],
           "nested": {
-            "&[data-fui-focus-visible]": {
+            ":focus": {
               "tokens": [
                 {
                   "property": "borderRadius",
@@ -798,159 +798,221 @@
       }
     }
   },
-  "library/src/components/SplitButton/useSplitButtonStyles.styles.ts": {
+  "library/src/components/MenuButton/useMenuButtonStyles.styles.ts": {
     "styles": {
-      "useFocusStyles": {},
-      "useRootStyles": {
-        "primary": {
-          "tokens": [],
-          "nested": {
-            "[`& .${splitButtonClassNames.primaryActionButton}`]": {
-              "tokens": [
-                {
-                  "property": "borderRightColor",
-                  "token": "tokens.colorNeutralStrokeOnBrand",
-                  "path": []
-                }
-              ]
-            },
-            "':hover'": {
-              "tokens": [
-                {
-                  "property": "borderRightColor",
-                  "token": "tokens.colorNeutralStrokeOnBrand",
-                  "path": []
-                }
-              ]
-            },
-            "':hover:active'": {
-              "tokens": [
-                {
-                  "property": "borderRightColor",
-                  "token": "tokens.colorNeutralStrokeOnBrand",
-                  "path": []
-                }
+      "useRootExpandedStyles": {
+        "outline": {
+          "tokens": [
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground1Selected",
+              "path": [
+                "color"
               ]
             }
-          },
+          ],
           "assignedVariables": [
-            "rootStyles"
+            "rootExpandedStyles"
+          ]
+        },
+        "primary": {
+          "tokens": [
+            {
+              "property": "backgroundColor",
+              "token": "tokens.colorBrandBackgroundSelected",
+              "path": [
+                "backgroundColor"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "rootExpandedStyles"
+          ]
+        },
+        "secondary": {
+          "tokens": [
+            {
+              "property": "backgroundColor",
+              "token": "tokens.colorNeutralBackground1Selected",
+              "path": [
+                "backgroundColor"
+              ]
+            },
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground1Selected",
+              "path": [
+                "color"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "rootExpandedStyles"
           ]
         },
         "subtle": {
-          "tokens": [],
-          "nested": {
-            "[`& .${splitButtonClassNames.primaryActionButton}`]": {
-              "tokens": [
-                {
-                  "property": "borderRightColor",
-                  "token": "tokens.colorNeutralStroke1",
-                  "path": []
-                }
+          "tokens": [
+            {
+              "property": "backgroundColor",
+              "token": "tokens.colorSubtleBackgroundSelected",
+              "path": [
+                "backgroundColor"
               ]
             },
-            "':hover'": {
-              "tokens": [
-                {
-                  "property": "borderRightColor",
-                  "token": "tokens.colorNeutralStroke1Hover",
-                  "path": []
-                }
-              ]
-            },
-            "':hover:active'": {
-              "tokens": [
-                {
-                  "property": "borderRightColor",
-                  "token": "tokens.colorNeutralStroke1Pressed",
-                  "path": []
-                }
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground2Selected",
+              "path": [
+                "color"
               ]
             }
-          },
+          ],
           "assignedVariables": [
-            "rootStyles"
+            "rootExpandedStyles"
           ]
         },
         "transparent": {
-          "tokens": [],
-          "nested": {
-            "[`& .${splitButtonClassNames.primaryActionButton}`]": {
-              "tokens": [
-                {
-                  "property": "borderRightColor",
-                  "token": "tokens.colorNeutralStroke1",
-                  "path": []
-                }
+          "tokens": [
+            {
+              "property": "backgroundColor",
+              "token": "tokens.colorTransparentBackgroundSelected",
+              "path": [
+                "backgroundColor"
               ]
             },
-            "':hover'": {
-              "tokens": [
-                {
-                  "property": "borderRightColor",
-                  "token": "tokens.colorNeutralStroke1Hover",
-                  "path": []
-                }
-              ]
-            },
-            "':hover:active'": {
-              "tokens": [
-                {
-                  "property": "borderRightColor",
-                  "token": "tokens.colorNeutralStroke1Pressed",
-                  "path": []
-                }
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground2BrandSelected",
+              "path": [
+                "color"
               ]
             }
-          },
+          ],
           "assignedVariables": [
-            "rootStyles"
+            "rootExpandedStyles"
+          ]
+        }
+      },
+      "useIconExpandedStyles": {
+        "outline": {
+          "tokens": [
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground1Selected",
+              "path": [
+                "color"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "iconExpandedStyles"
           ]
         },
-        "disabled": {
-          "tokens": [],
-          "nested": {
-            "[`& .${splitButtonClassNames.primaryActionButton}`]": {
-              "tokens": [
-                {
-                  "property": "borderRightColor",
-                  "token": "tokens.colorNeutralStrokeDisabled",
-                  "path": []
-                }
-              ]
-            },
-            "':hover'": {
-              "tokens": [
-                {
-                  "property": "borderRightColor",
-                  "token": "tokens.colorNeutralStrokeDisabled",
-                  "path": []
-                }
-              ]
-            },
-            "':hover:active'": {
-              "tokens": [
-                {
-                  "property": "borderRightColor",
-                  "token": "tokens.colorNeutralStrokeDisabled",
-                  "path": []
-                }
+        "secondary": {
+          "tokens": [
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground1Selected",
+              "path": [
+                "color"
               ]
             }
-          },
+          ],
           "assignedVariables": [
-            "rootStyles"
+            "iconExpandedStyles"
+          ]
+        },
+        "subtle": {
+          "tokens": [
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground2BrandSelected",
+              "path": [
+                "color"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "iconExpandedStyles"
+          ]
+        },
+        "transparent": {
+          "tokens": [
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground2BrandSelected",
+              "path": [
+                "color"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "iconExpandedStyles"
+          ]
+        }
+      },
+      "useMenuIconStyles": {
+        "small": {
+          "tokens": [
+            {
+              "property": "lineHeight",
+              "token": "tokens.lineHeightBase200",
+              "path": [
+                "lineHeight"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "menuIconStyles"
+          ]
+        },
+        "medium": {
+          "tokens": [
+            {
+              "property": "lineHeight",
+              "token": "tokens.lineHeightBase200",
+              "path": [
+                "lineHeight"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "menuIconStyles"
+          ]
+        },
+        "large": {
+          "tokens": [
+            {
+              "property": "lineHeight",
+              "token": "tokens.lineHeightBase400",
+              "path": [
+                "lineHeight"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "menuIconStyles"
+          ]
+        },
+        "notIconOnly": {
+          "tokens": [
+            {
+              "property": "marginLeft",
+              "token": "tokens.spacingHorizontalXS",
+              "path": [
+                "marginLeft"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "menuIconStyles"
           ]
         }
       }
     },
     "metadata": {
       "styleConditions": {
-        "splitButtonClassNames.root": {
-          "isBase": true,
-          "slotName": "root"
-        },
-        "rootStyles.base": {
+        "menuButtonClassNames.root": {
           "isBase": true,
           "slotName": "root"
         },
@@ -958,41 +1020,43 @@
           "isBase": true,
           "slotName": "root"
         },
-        "rootStyles.disabled": {
+        "rootExpandedStyles.base": {
           "conditions": [
-            "(disabled || disabledFocusable)"
+            "state.root['aria-expanded']"
           ],
           "slotName": "root"
         },
-        "rootStyles.disabledHighContrast": {
+        "menuButtonClassNames.icon": {
+          "isBase": true,
+          "slotName": "icon"
+        },
+        "state.icon.className": {
+          "isBase": true,
+          "slotName": "icon"
+        },
+        "iconExpandedStyles.highContrast": {
           "conditions": [
-            "(disabled || disabledFocusable)"
+            "state.root['aria-expanded'] && iconExpandedStyles[state.appearance]"
           ],
-          "slotName": "root"
+          "slotName": "icon"
         },
-        "splitButtonClassNames.menuButton": {
+        "menuButtonClassNames.menuIcon": {
           "isBase": true,
-          "slotName": "menuButton"
+          "slotName": "menuIcon"
         },
-        "focusStyles.menuButton": {
+        "menuIconStyles.base": {
           "isBase": true,
-          "slotName": "menuButton"
+          "slotName": "menuIcon"
         },
-        "state.menuButton.className": {
+        "state.menuIcon.className": {
           "isBase": true,
-          "slotName": "menuButton"
+          "slotName": "menuIcon"
         },
-        "splitButtonClassNames.primaryActionButton": {
-          "isBase": true,
-          "slotName": "primaryActionButton"
-        },
-        "focusStyles.primaryActionButton": {
-          "isBase": true,
-          "slotName": "primaryActionButton"
-        },
-        "state.primaryActionButton.className": {
-          "isBase": true,
-          "slotName": "primaryActionButton"
+        "menuIconStyles.notIconOnly": {
+          "conditions": [
+            "!state.iconOnly"
+          ],
+          "slotName": "menuIcon"
         }
       }
     }
@@ -1450,221 +1514,159 @@
       }
     }
   },
-  "library/src/components/MenuButton/useMenuButtonStyles.styles.ts": {
+  "library/src/components/SplitButton/useSplitButtonStyles.styles.ts": {
     "styles": {
-      "useRootExpandedStyles": {
-        "outline": {
-          "tokens": [
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground1Selected",
-              "path": [
-                "color"
-              ]
-            }
-          ],
-          "assignedVariables": [
-            "rootExpandedStyles"
-          ]
-        },
+      "useFocusStyles": {},
+      "useRootStyles": {
         "primary": {
-          "tokens": [
-            {
-              "property": "backgroundColor",
-              "token": "tokens.colorBrandBackgroundSelected",
-              "path": [
-                "backgroundColor"
-              ]
-            }
-          ],
-          "assignedVariables": [
-            "rootExpandedStyles"
-          ]
-        },
-        "secondary": {
-          "tokens": [
-            {
-              "property": "backgroundColor",
-              "token": "tokens.colorNeutralBackground1Selected",
-              "path": [
-                "backgroundColor"
+          "tokens": [],
+          "nested": {
+            "[`& .${splitButtonClassNames.primaryActionButton}`]": {
+              "tokens": [
+                {
+                  "property": "borderRightColor",
+                  "token": "tokens.colorNeutralStrokeOnBrand",
+                  "path": []
+                }
               ]
             },
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground1Selected",
-              "path": [
-                "color"
+            "':hover'": {
+              "tokens": [
+                {
+                  "property": "borderRightColor",
+                  "token": "tokens.colorNeutralStrokeOnBrand",
+                  "path": []
+                }
+              ]
+            },
+            "':hover:active'": {
+              "tokens": [
+                {
+                  "property": "borderRightColor",
+                  "token": "tokens.colorNeutralStrokeOnBrand",
+                  "path": []
+                }
               ]
             }
-          ],
+          },
           "assignedVariables": [
-            "rootExpandedStyles"
+            "rootStyles"
           ]
         },
         "subtle": {
-          "tokens": [
-            {
-              "property": "backgroundColor",
-              "token": "tokens.colorSubtleBackgroundSelected",
-              "path": [
-                "backgroundColor"
+          "tokens": [],
+          "nested": {
+            "[`& .${splitButtonClassNames.primaryActionButton}`]": {
+              "tokens": [
+                {
+                  "property": "borderRightColor",
+                  "token": "tokens.colorNeutralStroke1",
+                  "path": []
+                }
               ]
             },
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground2Selected",
-              "path": [
-                "color"
+            "':hover'": {
+              "tokens": [
+                {
+                  "property": "borderRightColor",
+                  "token": "tokens.colorNeutralStroke1Hover",
+                  "path": []
+                }
+              ]
+            },
+            "':hover:active'": {
+              "tokens": [
+                {
+                  "property": "borderRightColor",
+                  "token": "tokens.colorNeutralStroke1Pressed",
+                  "path": []
+                }
               ]
             }
-          ],
+          },
           "assignedVariables": [
-            "rootExpandedStyles"
+            "rootStyles"
           ]
         },
         "transparent": {
-          "tokens": [
-            {
-              "property": "backgroundColor",
-              "token": "tokens.colorTransparentBackgroundSelected",
-              "path": [
-                "backgroundColor"
+          "tokens": [],
+          "nested": {
+            "[`& .${splitButtonClassNames.primaryActionButton}`]": {
+              "tokens": [
+                {
+                  "property": "borderRightColor",
+                  "token": "tokens.colorNeutralStroke1",
+                  "path": []
+                }
               ]
             },
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground2BrandSelected",
-              "path": [
-                "color"
+            "':hover'": {
+              "tokens": [
+                {
+                  "property": "borderRightColor",
+                  "token": "tokens.colorNeutralStroke1Hover",
+                  "path": []
+                }
+              ]
+            },
+            "':hover:active'": {
+              "tokens": [
+                {
+                  "property": "borderRightColor",
+                  "token": "tokens.colorNeutralStroke1Pressed",
+                  "path": []
+                }
               ]
             }
-          ],
+          },
           "assignedVariables": [
-            "rootExpandedStyles"
-          ]
-        }
-      },
-      "useIconExpandedStyles": {
-        "outline": {
-          "tokens": [
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground1Selected",
-              "path": [
-                "color"
-              ]
-            }
-          ],
-          "assignedVariables": [
-            "iconExpandedStyles"
+            "rootStyles"
           ]
         },
-        "secondary": {
-          "tokens": [
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground1Selected",
-              "path": [
-                "color"
+        "disabled": {
+          "tokens": [],
+          "nested": {
+            "[`& .${splitButtonClassNames.primaryActionButton}`]": {
+              "tokens": [
+                {
+                  "property": "borderRightColor",
+                  "token": "tokens.colorNeutralStrokeDisabled",
+                  "path": []
+                }
+              ]
+            },
+            "':hover'": {
+              "tokens": [
+                {
+                  "property": "borderRightColor",
+                  "token": "tokens.colorNeutralStrokeDisabled",
+                  "path": []
+                }
+              ]
+            },
+            "':hover:active'": {
+              "tokens": [
+                {
+                  "property": "borderRightColor",
+                  "token": "tokens.colorNeutralStrokeDisabled",
+                  "path": []
+                }
               ]
             }
-          ],
+          },
           "assignedVariables": [
-            "iconExpandedStyles"
-          ]
-        },
-        "subtle": {
-          "tokens": [
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground2BrandSelected",
-              "path": [
-                "color"
-              ]
-            }
-          ],
-          "assignedVariables": [
-            "iconExpandedStyles"
-          ]
-        },
-        "transparent": {
-          "tokens": [
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground2BrandSelected",
-              "path": [
-                "color"
-              ]
-            }
-          ],
-          "assignedVariables": [
-            "iconExpandedStyles"
-          ]
-        }
-      },
-      "useMenuIconStyles": {
-        "small": {
-          "tokens": [
-            {
-              "property": "lineHeight",
-              "token": "tokens.lineHeightBase200",
-              "path": [
-                "lineHeight"
-              ]
-            }
-          ],
-          "assignedVariables": [
-            "menuIconStyles"
-          ]
-        },
-        "medium": {
-          "tokens": [
-            {
-              "property": "lineHeight",
-              "token": "tokens.lineHeightBase200",
-              "path": [
-                "lineHeight"
-              ]
-            }
-          ],
-          "assignedVariables": [
-            "menuIconStyles"
-          ]
-        },
-        "large": {
-          "tokens": [
-            {
-              "property": "lineHeight",
-              "token": "tokens.lineHeightBase400",
-              "path": [
-                "lineHeight"
-              ]
-            }
-          ],
-          "assignedVariables": [
-            "menuIconStyles"
-          ]
-        },
-        "notIconOnly": {
-          "tokens": [
-            {
-              "property": "marginLeft",
-              "token": "tokens.spacingHorizontalXS",
-              "path": [
-                "marginLeft"
-              ]
-            }
-          ],
-          "assignedVariables": [
-            "menuIconStyles"
+            "rootStyles"
           ]
         }
       }
     },
     "metadata": {
       "styleConditions": {
-        "menuButtonClassNames.root": {
+        "splitButtonClassNames.root": {
+          "isBase": true,
+          "slotName": "root"
+        },
+        "rootStyles.base": {
           "isBase": true,
           "slotName": "root"
         },
@@ -1672,43 +1674,41 @@
           "isBase": true,
           "slotName": "root"
         },
-        "rootExpandedStyles.base": {
+        "rootStyles.disabled": {
           "conditions": [
-            "state.root['aria-expanded']"
+            "(disabled || disabledFocusable)"
           ],
           "slotName": "root"
         },
-        "menuButtonClassNames.icon": {
-          "isBase": true,
-          "slotName": "icon"
-        },
-        "state.icon.className": {
-          "isBase": true,
-          "slotName": "icon"
-        },
-        "iconExpandedStyles.highContrast": {
+        "rootStyles.disabledHighContrast": {
           "conditions": [
-            "state.root['aria-expanded'] && iconExpandedStyles[state.appearance]"
+            "(disabled || disabledFocusable)"
           ],
-          "slotName": "icon"
+          "slotName": "root"
         },
-        "menuButtonClassNames.menuIcon": {
+        "splitButtonClassNames.menuButton": {
           "isBase": true,
-          "slotName": "menuIcon"
+          "slotName": "menuButton"
         },
-        "menuIconStyles.base": {
+        "focusStyles.menuButton": {
           "isBase": true,
-          "slotName": "menuIcon"
+          "slotName": "menuButton"
         },
-        "state.menuIcon.className": {
+        "state.menuButton.className": {
           "isBase": true,
-          "slotName": "menuIcon"
+          "slotName": "menuButton"
         },
-        "menuIconStyles.notIconOnly": {
-          "conditions": [
-            "!state.iconOnly"
-          ],
-          "slotName": "menuIcon"
+        "splitButtonClassNames.primaryActionButton": {
+          "isBase": true,
+          "slotName": "primaryActionButton"
+        },
+        "focusStyles.primaryActionButton": {
+          "isBase": true,
+          "slotName": "primaryActionButton"
+        },
+        "state.primaryActionButton.className": {
+          "isBase": true,
+          "slotName": "primaryActionButton"
         }
       }
     }

--- a/packages/react-components/token-analyzer-preview/library/analysis.json
+++ b/packages/react-components/token-analyzer-preview/library/analysis.json
@@ -1,389 +1,4 @@
 {
-  "library/src/components/CompoundButton/useCompoundButtonStyles.styles.ts": {
-    "styles": {
-      "useRootStyles": {
-        "base": {
-          "tokens": [],
-          "nested": {
-            "[`& .${compoundButtonClassNames.secondaryContent}`]": {
-              "tokens": [
-                {
-                  "property": "color",
-                  "token": "tokens.colorNeutralForeground2",
-                  "path": []
-                }
-              ]
-            },
-            "':hover'": {
-              "tokens": [
-                {
-                  "property": "color",
-                  "token": "tokens.colorNeutralForeground2Hover",
-                  "path": []
-                }
-              ]
-            },
-            "':hover:active'": {
-              "tokens": [
-                {
-                  "property": "color",
-                  "token": "tokens.colorNeutralForeground2Pressed",
-                  "path": []
-                }
-              ]
-            }
-          },
-          "assignedVariables": ["rootStyles"]
-        },
-        "primary": {
-          "tokens": [],
-          "nested": {
-            "[`& .${compoundButtonClassNames.secondaryContent}`]": {
-              "tokens": [
-                {
-                  "property": "color",
-                  "token": "tokens.colorNeutralForegroundOnBrand",
-                  "path": []
-                }
-              ]
-            },
-            "':hover'": {
-              "tokens": [
-                {
-                  "property": "color",
-                  "token": "tokens.colorNeutralForegroundOnBrand",
-                  "path": []
-                }
-              ]
-            },
-            "':hover:active'": {
-              "tokens": [
-                {
-                  "property": "color",
-                  "token": "tokens.colorNeutralForegroundOnBrand",
-                  "path": []
-                }
-              ]
-            }
-          },
-          "assignedVariables": ["rootStyles"]
-        },
-        "subtle": {
-          "tokens": [],
-          "nested": {
-            "[`& .${compoundButtonClassNames.secondaryContent}`]": {
-              "tokens": [
-                {
-                  "property": "color",
-                  "token": "tokens.colorNeutralForeground2",
-                  "path": []
-                }
-              ]
-            },
-            "':hover'": {
-              "tokens": [
-                {
-                  "property": "color",
-                  "token": "tokens.colorNeutralForeground2Hover",
-                  "path": []
-                }
-              ]
-            },
-            "':hover:active'": {
-              "tokens": [
-                {
-                  "property": "color",
-                  "token": "tokens.colorNeutralForeground2Pressed",
-                  "path": []
-                }
-              ]
-            }
-          },
-          "assignedVariables": ["rootStyles"]
-        },
-        "transparent": {
-          "tokens": [],
-          "nested": {
-            "[`& .${compoundButtonClassNames.secondaryContent}`]": {
-              "tokens": [
-                {
-                  "property": "color",
-                  "token": "tokens.colorNeutralForeground2",
-                  "path": []
-                }
-              ]
-            },
-            "':hover'": {
-              "tokens": [
-                {
-                  "property": "color",
-                  "token": "tokens.colorNeutralForeground2BrandHover",
-                  "path": []
-                }
-              ]
-            },
-            "':hover:active'": {
-              "tokens": [
-                {
-                  "property": "color",
-                  "token": "tokens.colorNeutralForeground2BrandPressed",
-                  "path": []
-                }
-              ]
-            }
-          },
-          "assignedVariables": ["rootStyles"]
-        },
-        "small": {
-          "tokens": [
-            {
-              "property": "fontSize",
-              "token": "tokens.fontSizeBase300",
-              "path": ["fontSize"]
-            },
-            {
-              "property": "lineHeight",
-              "token": "tokens.lineHeightBase300",
-              "path": ["lineHeight"]
-            }
-          ],
-          "assignedVariables": ["rootStyles"]
-        },
-        "medium": {
-          "tokens": [
-            {
-              "property": "fontSize",
-              "token": "tokens.fontSizeBase300",
-              "path": ["fontSize"]
-            },
-            {
-              "property": "lineHeight",
-              "token": "tokens.lineHeightBase300",
-              "path": ["lineHeight"]
-            }
-          ],
-          "assignedVariables": ["rootStyles"]
-        },
-        "large": {
-          "tokens": [
-            {
-              "property": "fontSize",
-              "token": "tokens.fontSizeBase400",
-              "path": ["fontSize"]
-            },
-            {
-              "property": "lineHeight",
-              "token": "tokens.lineHeightBase400",
-              "path": ["lineHeight"]
-            }
-          ],
-          "assignedVariables": ["rootStyles"]
-        },
-        "disabled": {
-          "tokens": [],
-          "nested": {
-            "[`& .${compoundButtonClassNames.secondaryContent}`]": {
-              "tokens": [
-                {
-                  "property": "color",
-                  "token": "tokens.colorNeutralForegroundDisabled",
-                  "path": []
-                }
-              ]
-            },
-            "':hover'": {
-              "tokens": [
-                {
-                  "property": "color",
-                  "token": "tokens.colorNeutralForegroundDisabled",
-                  "path": []
-                }
-              ]
-            },
-            "':hover:active'": {
-              "tokens": [
-                {
-                  "property": "color",
-                  "token": "tokens.colorNeutralForegroundDisabled",
-                  "path": []
-                }
-              ]
-            }
-          },
-          "assignedVariables": ["rootStyles"]
-        }
-      },
-      "useRootIconOnlyStyles": {
-        "small": {
-          "tokens": [
-            {
-              "property": "padding",
-              "token": "tokens.spacingHorizontalXS",
-              "path": ["padding"]
-            }
-          ],
-          "assignedVariables": ["rootIconOnlyStyles"]
-        },
-        "medium": {
-          "tokens": [
-            {
-              "property": "padding",
-              "token": "tokens.spacingHorizontalSNudge",
-              "path": ["padding"]
-            }
-          ],
-          "assignedVariables": ["rootIconOnlyStyles"]
-        },
-        "large": {
-          "tokens": [
-            {
-              "property": "padding",
-              "token": "tokens.spacingHorizontalS",
-              "path": ["padding"]
-            }
-          ],
-          "assignedVariables": ["rootIconOnlyStyles"]
-        }
-      },
-      "useIconStyles": {
-        "before": {
-          "tokens": [
-            {
-              "property": "marginRight",
-              "token": "tokens.spacingHorizontalM",
-              "path": ["marginRight"]
-            }
-          ],
-          "assignedVariables": ["iconStyles"]
-        },
-        "after": {
-          "tokens": [
-            {
-              "property": "marginLeft",
-              "token": "tokens.spacingHorizontalM",
-              "path": ["marginLeft"]
-            }
-          ],
-          "assignedVariables": ["iconStyles"]
-        }
-      },
-      "useContentContainerStyles": {},
-      "useSecondaryContentStyles": {
-        "base": {
-          "tokens": [
-            {
-              "property": "fontWeight",
-              "token": "tokens.fontWeightRegular",
-              "path": ["fontWeight"]
-            }
-          ],
-          "assignedVariables": ["secondaryContentStyles"]
-        },
-        "small": {
-          "tokens": [
-            {
-              "property": "fontSize",
-              "token": "tokens.fontSizeBase200",
-              "path": ["fontSize"]
-            }
-          ],
-          "assignedVariables": ["secondaryContentStyles"]
-        },
-        "medium": {
-          "tokens": [
-            {
-              "property": "fontSize",
-              "token": "tokens.fontSizeBase200",
-              "path": ["fontSize"]
-            }
-          ],
-          "assignedVariables": ["secondaryContentStyles"]
-        },
-        "large": {
-          "tokens": [
-            {
-              "property": "fontSize",
-              "token": "tokens.fontSizeBase300",
-              "path": ["fontSize"]
-            }
-          ],
-          "assignedVariables": ["secondaryContentStyles"]
-        }
-      }
-    },
-    "metadata": {
-      "styleConditions": {
-        "compoundButtonClassNames.root": {
-          "isBase": true,
-          "slotName": "root"
-        },
-        "rootStyles.base": {
-          "isBase": true,
-          "slotName": "root"
-        },
-        "rootStyles.highContrast": {
-          "isBase": true,
-          "slotName": "root"
-        },
-        "rootStyles[size]": {
-          "isBase": true,
-          "slotName": "root"
-        },
-        "state.root.className": {
-          "isBase": true,
-          "slotName": "root"
-        },
-        "rootStyles.disabled": {
-          "conditions": ["(disabled || disabledFocusable)"],
-          "slotName": "root"
-        },
-        "rootStyles.disabledHighContrast": {
-          "conditions": ["(disabled || disabledFocusable)"],
-          "slotName": "root"
-        },
-        "compoundButtonClassNames.contentContainer": {
-          "isBase": true,
-          "slotName": "contentContainer"
-        },
-        "contentContainerStyles.base": {
-          "isBase": true,
-          "slotName": "contentContainer"
-        },
-        "state.contentContainer.className": {
-          "isBase": true,
-          "slotName": "contentContainer"
-        },
-        "compoundButtonClassNames.icon": {
-          "isBase": true,
-          "slotName": "icon"
-        },
-        "iconStyles.base": {
-          "isBase": true,
-          "slotName": "icon"
-        },
-        "state.icon.className": {
-          "isBase": true,
-          "slotName": "icon"
-        },
-        "compoundButtonClassNames.secondaryContent": {
-          "isBase": true,
-          "slotName": "secondaryContent"
-        },
-        "secondaryContentStyles.base": {
-          "isBase": true,
-          "slotName": "secondaryContent"
-        },
-        "secondaryContentStyles[size]": {
-          "isBase": true,
-          "slotName": "secondaryContent"
-        },
-        "state.secondaryContent.className": {
-          "isBase": true,
-          "slotName": "secondaryContent"
-        }
-      }
-    }
-  },
   "library/src/components/Button/useButtonStyles.styles.ts": {
     "styles": {
       "useRootBaseClassName": {
@@ -392,47 +7,65 @@
             {
               "property": "backgroundColor",
               "token": "tokens.colorNeutralBackground1",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             },
             {
               "property": "color",
               "token": "tokens.colorNeutralForeground1",
-              "path": ["color"]
+              "path": [
+                "color"
+              ]
             },
             {
               "property": "fontFamily",
               "token": "tokens.fontFamilyBase",
-              "path": ["fontFamily"]
+              "path": [
+                "fontFamily"
+              ]
             },
             {
               "property": "borderRadius",
               "token": "tokens.borderRadiusMedium",
-              "path": ["borderRadius"]
+              "path": [
+                "borderRadius"
+              ]
             },
             {
               "property": "fontSize",
               "token": "tokens.fontSizeBase300",
-              "path": ["fontSize"]
+              "path": [
+                "fontSize"
+              ]
             },
             {
               "property": "fontWeight",
               "token": "tokens.fontWeightSemibold",
-              "path": ["fontWeight"]
+              "path": [
+                "fontWeight"
+              ]
             },
             {
               "property": "lineHeight",
               "token": "tokens.lineHeightBase300",
-              "path": ["lineHeight"]
+              "path": [
+                "lineHeight"
+              ]
             },
             {
               "property": "transitionDuration",
               "token": "tokens.durationFaster",
-              "path": ["transitionDuration"]
+              "path": [
+                "transitionDuration"
+              ]
             },
             {
               "property": "transitionTimingFunction",
               "token": "tokens.curveEasyEase",
-              "path": ["transitionTimingFunction"]
+              "path": [
+                "transitionTimingFunction"
+              ]
             }
           ],
           "nested": {
@@ -476,7 +109,9 @@
             }
           },
           "isResetStyles": true,
-          "assignedVariables": ["rootBaseClassName"]
+          "assignedVariables": [
+            "rootBaseClassName"
+          ]
         }
       },
       "useIconBaseClassName": {
@@ -485,12 +120,16 @@
             {
               "property": "[iconSpacingVar]",
               "token": "tokens.spacingHorizontalSNudge",
-              "path": ["[iconSpacingVar]"]
+              "path": [
+                "[iconSpacingVar]"
+              ]
             }
           ],
           "nested": {},
           "isResetStyles": true,
-          "assignedVariables": ["iconBaseClassName"]
+          "assignedVariables": [
+            "iconBaseClassName"
+          ]
         }
       },
       "useRootStyles": {
@@ -499,7 +138,9 @@
             {
               "property": "backgroundColor",
               "token": "tokens.colorTransparentBackground",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             }
           ],
           "nested": {
@@ -522,19 +163,25 @@
               ]
             }
           },
-          "assignedVariables": ["rootStyles"]
+          "assignedVariables": [
+            "rootStyles"
+          ]
         },
         "primary": {
           "tokens": [
             {
               "property": "backgroundColor",
               "token": "tokens.colorBrandBackground",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             },
             {
               "property": "color",
               "token": "tokens.colorNeutralForegroundOnBrand",
-              "path": ["color"]
+              "path": [
+                "color"
+              ]
             }
           ],
           "nested": {
@@ -567,19 +214,25 @@
               ]
             }
           },
-          "assignedVariables": ["rootStyles"]
+          "assignedVariables": [
+            "rootStyles"
+          ]
         },
         "subtle": {
           "tokens": [
             {
               "property": "backgroundColor",
               "token": "tokens.colorSubtleBackground",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             },
             {
               "property": "color",
               "token": "tokens.colorNeutralForeground2",
-              "path": ["color"]
+              "path": [
+                "color"
+              ]
             }
           ],
           "nested": {
@@ -622,19 +275,25 @@
               ]
             }
           },
-          "assignedVariables": ["rootStyles"]
+          "assignedVariables": [
+            "rootStyles"
+          ]
         },
         "transparent": {
           "tokens": [
             {
               "property": "backgroundColor",
               "token": "tokens.colorTransparentBackground",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             },
             {
               "property": "color",
               "token": "tokens.colorNeutralForeground2",
-              "path": ["color"]
+              "path": [
+                "color"
+              ]
             }
           ],
           "nested": {
@@ -681,77 +340,107 @@
               ]
             }
           },
-          "assignedVariables": ["rootStyles"]
+          "assignedVariables": [
+            "rootStyles"
+          ]
         },
         "circular": {
           "tokens": [
             {
               "property": "borderRadius",
               "token": "tokens.borderRadiusCircular",
-              "path": ["borderRadius"]
+              "path": [
+                "borderRadius"
+              ]
             }
           ],
-          "assignedVariables": ["rootStyles"]
+          "assignedVariables": [
+            "rootStyles"
+          ]
         },
         "square": {
           "tokens": [
             {
               "property": "borderRadius",
               "token": "tokens.borderRadiusNone",
-              "path": ["borderRadius"]
+              "path": [
+                "borderRadius"
+              ]
             }
           ],
-          "assignedVariables": ["rootStyles"]
+          "assignedVariables": [
+            "rootStyles"
+          ]
         },
         "small": {
           "tokens": [
             {
               "property": "borderRadius",
               "token": "tokens.borderRadiusMedium",
-              "path": ["borderRadius"]
+              "path": [
+                "borderRadius"
+              ]
             },
             {
               "property": "fontSize",
               "token": "tokens.fontSizeBase200",
-              "path": ["fontSize"]
+              "path": [
+                "fontSize"
+              ]
             },
             {
               "property": "fontWeight",
               "token": "tokens.fontWeightRegular",
-              "path": ["fontWeight"]
+              "path": [
+                "fontWeight"
+              ]
             },
             {
               "property": "lineHeight",
               "token": "tokens.lineHeightBase200",
-              "path": ["lineHeight"]
+              "path": [
+                "lineHeight"
+              ]
             }
           ],
-          "assignedVariables": ["rootStyles"]
+          "assignedVariables": [
+            "rootStyles"
+          ]
         },
         "large": {
           "tokens": [
             {
               "property": "borderRadius",
               "token": "tokens.borderRadiusMedium",
-              "path": ["borderRadius"]
+              "path": [
+                "borderRadius"
+              ]
             },
             {
               "property": "fontSize",
               "token": "tokens.fontSizeBase400",
-              "path": ["fontSize"]
+              "path": [
+                "fontSize"
+              ]
             },
             {
               "property": "fontWeight",
               "token": "tokens.fontWeightSemibold",
-              "path": ["fontWeight"]
+              "path": [
+                "fontWeight"
+              ]
             },
             {
               "property": "lineHeight",
               "token": "tokens.lineHeightBase400",
-              "path": ["lineHeight"]
+              "path": [
+                "lineHeight"
+              ]
             }
           ],
-          "assignedVariables": ["rootStyles"]
+          "assignedVariables": [
+            "rootStyles"
+          ]
         }
       },
       "useRootDisabledStyles": {
@@ -760,12 +449,16 @@
             {
               "property": "backgroundColor",
               "token": "tokens.colorNeutralBackgroundDisabled",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             },
             {
               "property": "color",
               "token": "tokens.colorNeutralForegroundDisabled",
-              "path": ["color"]
+              "path": [
+                "color"
+              ]
             }
           ],
           "nested": {
@@ -817,14 +510,18 @@
               ]
             }
           },
-          "assignedVariables": ["rootDisabledStyles"]
+          "assignedVariables": [
+            "rootDisabledStyles"
+          ]
         },
         "outline": {
           "tokens": [
             {
               "property": "backgroundColor",
               "token": "tokens.colorTransparentBackground",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             }
           ],
           "nested": {
@@ -847,14 +544,18 @@
               ]
             }
           },
-          "assignedVariables": ["rootDisabledStyles"]
+          "assignedVariables": [
+            "rootDisabledStyles"
+          ]
         },
         "subtle": {
           "tokens": [
             {
               "property": "backgroundColor",
               "token": "tokens.colorTransparentBackground",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             }
           ],
           "nested": {
@@ -877,14 +578,18 @@
               ]
             }
           },
-          "assignedVariables": ["rootDisabledStyles"]
+          "assignedVariables": [
+            "rootDisabledStyles"
+          ]
         },
         "transparent": {
           "tokens": [
             {
               "property": "backgroundColor",
               "token": "tokens.colorTransparentBackground",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             }
           ],
           "nested": {
@@ -907,10 +612,81 @@
               ]
             }
           },
-          "assignedVariables": ["rootDisabledStyles"]
+          "assignedVariables": [
+            "rootDisabledStyles"
+          ]
         }
       },
-      "useRootFocusStyles": {},
+      "useRootFocusStyles": {
+        "circular": {
+          "tokens": [],
+          "nested": {
+            "&[data-fui-focus-visible]": {
+              "tokens": [
+                {
+                  "property": "borderRadius",
+                  "token": "tokens.borderRadiusCircular",
+                  "path": []
+                }
+              ]
+            }
+          },
+          "assignedVariables": [
+            "rootFocusStyles"
+          ]
+        },
+        "square": {
+          "tokens": [],
+          "nested": {
+            "&[data-fui-focus-visible]": {
+              "tokens": [
+                {
+                  "property": "borderRadius",
+                  "token": "tokens.borderRadiusNone",
+                  "path": []
+                }
+              ]
+            }
+          },
+          "assignedVariables": [
+            "rootFocusStyles"
+          ]
+        },
+        "small": {
+          "tokens": [],
+          "nested": {
+            "&[data-fui-focus-visible]": {
+              "tokens": [
+                {
+                  "property": "borderRadius",
+                  "token": "tokens.borderRadiusSmall",
+                  "path": []
+                }
+              ]
+            }
+          },
+          "assignedVariables": [
+            "rootFocusStyles"
+          ]
+        },
+        "large": {
+          "tokens": [],
+          "nested": {
+            "&[data-fui-focus-visible]": {
+              "tokens": [
+                {
+                  "property": "borderRadius",
+                  "token": "tokens.borderRadiusLarge",
+                  "path": []
+                }
+              ]
+            }
+          },
+          "assignedVariables": [
+            "rootFocusStyles"
+          ]
+        }
+      },
       "useRootIconOnlyStyles": {},
       "useIconStyles": {
         "small": {
@@ -918,20 +694,28 @@
             {
               "property": "[iconSpacingVar]",
               "token": "tokens.spacingHorizontalXS",
-              "path": ["[iconSpacingVar]"]
+              "path": [
+                "[iconSpacingVar]"
+              ]
             }
           ],
-          "assignedVariables": ["iconStyles"]
+          "assignedVariables": [
+            "iconStyles"
+          ]
         },
         "large": {
           "tokens": [
             {
               "property": "[iconSpacingVar]",
               "token": "tokens.spacingHorizontalSNudge",
-              "path": ["[iconSpacingVar]"]
+              "path": [
+                "[iconSpacingVar]"
+              ]
             }
           ],
-          "assignedVariables": ["iconStyles"]
+          "assignedVariables": [
+            "iconStyles"
+          ]
         }
       }
     },
@@ -966,23 +750,33 @@
           "slotName": "root"
         },
         "rootStyles.smallWithIcon": {
-          "conditions": ["icon && size === 'small'"],
+          "conditions": [
+            "icon && size === 'small'"
+          ],
           "slotName": "root"
         },
         "rootStyles.largeWithIcon": {
-          "conditions": ["icon && size === 'large'"],
+          "conditions": [
+            "icon && size === 'large'"
+          ],
           "slotName": "root"
         },
         "rootDisabledStyles.base": {
-          "conditions": ["(disabled || disabledFocusable)"],
+          "conditions": [
+            "(disabled || disabledFocusable)"
+          ],
           "slotName": "root"
         },
         "rootDisabledStyles.highContrast": {
-          "conditions": ["(disabled || disabledFocusable)"],
+          "conditions": [
+            "(disabled || disabledFocusable)"
+          ],
           "slotName": "root"
         },
         "rootFocusStyles.primary": {
-          "conditions": ["appearance === 'primary'"],
+          "conditions": [
+            "appearance === 'primary'"
+          ],
           "slotName": "root"
         },
         "buttonClassNames.icon": {
@@ -1000,205 +794,6 @@
         "state.icon.className": {
           "isBase": true,
           "slotName": "icon"
-        }
-      }
-    }
-  },
-  "library/src/components/MenuButton/useMenuButtonStyles.styles.ts": {
-    "styles": {
-      "useRootExpandedStyles": {
-        "outline": {
-          "tokens": [
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground1Selected",
-              "path": ["color"]
-            }
-          ],
-          "assignedVariables": ["rootExpandedStyles"]
-        },
-        "primary": {
-          "tokens": [
-            {
-              "property": "backgroundColor",
-              "token": "tokens.colorBrandBackgroundSelected",
-              "path": ["backgroundColor"]
-            }
-          ],
-          "assignedVariables": ["rootExpandedStyles"]
-        },
-        "secondary": {
-          "tokens": [
-            {
-              "property": "backgroundColor",
-              "token": "tokens.colorNeutralBackground1Selected",
-              "path": ["backgroundColor"]
-            },
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground1Selected",
-              "path": ["color"]
-            }
-          ],
-          "assignedVariables": ["rootExpandedStyles"]
-        },
-        "subtle": {
-          "tokens": [
-            {
-              "property": "backgroundColor",
-              "token": "tokens.colorSubtleBackgroundSelected",
-              "path": ["backgroundColor"]
-            },
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground2Selected",
-              "path": ["color"]
-            }
-          ],
-          "assignedVariables": ["rootExpandedStyles"]
-        },
-        "transparent": {
-          "tokens": [
-            {
-              "property": "backgroundColor",
-              "token": "tokens.colorTransparentBackgroundSelected",
-              "path": ["backgroundColor"]
-            },
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground2BrandSelected",
-              "path": ["color"]
-            }
-          ],
-          "assignedVariables": ["rootExpandedStyles"]
-        }
-      },
-      "useIconExpandedStyles": {
-        "outline": {
-          "tokens": [
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground1Selected",
-              "path": ["color"]
-            }
-          ],
-          "assignedVariables": ["iconExpandedStyles"]
-        },
-        "secondary": {
-          "tokens": [
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground1Selected",
-              "path": ["color"]
-            }
-          ],
-          "assignedVariables": ["iconExpandedStyles"]
-        },
-        "subtle": {
-          "tokens": [
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground2BrandSelected",
-              "path": ["color"]
-            }
-          ],
-          "assignedVariables": ["iconExpandedStyles"]
-        },
-        "transparent": {
-          "tokens": [
-            {
-              "property": "color",
-              "token": "tokens.colorNeutralForeground2BrandSelected",
-              "path": ["color"]
-            }
-          ],
-          "assignedVariables": ["iconExpandedStyles"]
-        }
-      },
-      "useMenuIconStyles": {
-        "small": {
-          "tokens": [
-            {
-              "property": "lineHeight",
-              "token": "tokens.lineHeightBase200",
-              "path": ["lineHeight"]
-            }
-          ],
-          "assignedVariables": ["menuIconStyles"]
-        },
-        "medium": {
-          "tokens": [
-            {
-              "property": "lineHeight",
-              "token": "tokens.lineHeightBase200",
-              "path": ["lineHeight"]
-            }
-          ],
-          "assignedVariables": ["menuIconStyles"]
-        },
-        "large": {
-          "tokens": [
-            {
-              "property": "lineHeight",
-              "token": "tokens.lineHeightBase400",
-              "path": ["lineHeight"]
-            }
-          ],
-          "assignedVariables": ["menuIconStyles"]
-        },
-        "notIconOnly": {
-          "tokens": [
-            {
-              "property": "marginLeft",
-              "token": "tokens.spacingHorizontalXS",
-              "path": ["marginLeft"]
-            }
-          ],
-          "assignedVariables": ["menuIconStyles"]
-        }
-      }
-    },
-    "metadata": {
-      "styleConditions": {
-        "menuButtonClassNames.root": {
-          "isBase": true,
-          "slotName": "root"
-        },
-        "state.root.className": {
-          "isBase": true,
-          "slotName": "root"
-        },
-        "rootExpandedStyles.base": {
-          "conditions": ["state.root['aria-expanded']"],
-          "slotName": "root"
-        },
-        "menuButtonClassNames.icon": {
-          "isBase": true,
-          "slotName": "icon"
-        },
-        "state.icon.className": {
-          "isBase": true,
-          "slotName": "icon"
-        },
-        "iconExpandedStyles.highContrast": {
-          "conditions": ["state.root['aria-expanded'] && iconExpandedStyles[state.appearance]"],
-          "slotName": "icon"
-        },
-        "menuButtonClassNames.menuIcon": {
-          "isBase": true,
-          "slotName": "menuIcon"
-        },
-        "menuIconStyles.base": {
-          "isBase": true,
-          "slotName": "menuIcon"
-        },
-        "state.menuIcon.className": {
-          "isBase": true,
-          "slotName": "menuIcon"
-        },
-        "menuIconStyles.notIconOnly": {
-          "conditions": ["!state.iconOnly"],
-          "slotName": "menuIcon"
         }
       }
     }
@@ -1238,7 +833,9 @@
               ]
             }
           },
-          "assignedVariables": ["rootStyles"]
+          "assignedVariables": [
+            "rootStyles"
+          ]
         },
         "subtle": {
           "tokens": [],
@@ -1271,7 +868,9 @@
               ]
             }
           },
-          "assignedVariables": ["rootStyles"]
+          "assignedVariables": [
+            "rootStyles"
+          ]
         },
         "transparent": {
           "tokens": [],
@@ -1304,7 +903,9 @@
               ]
             }
           },
-          "assignedVariables": ["rootStyles"]
+          "assignedVariables": [
+            "rootStyles"
+          ]
         },
         "disabled": {
           "tokens": [],
@@ -1337,7 +938,9 @@
               ]
             }
           },
-          "assignedVariables": ["rootStyles"]
+          "assignedVariables": [
+            "rootStyles"
+          ]
         }
       }
     },
@@ -1356,11 +959,15 @@
           "slotName": "root"
         },
         "rootStyles.disabled": {
-          "conditions": ["(disabled || disabledFocusable)"],
+          "conditions": [
+            "(disabled || disabledFocusable)"
+          ],
           "slotName": "root"
         },
         "rootStyles.disabledHighContrast": {
-          "conditions": ["(disabled || disabledFocusable)"],
+          "conditions": [
+            "(disabled || disabledFocusable)"
+          ],
           "slotName": "root"
         },
         "splitButtonClassNames.menuButton": {
@@ -1390,6 +997,722 @@
       }
     }
   },
+  "library/src/components/CompoundButton/useCompoundButtonStyles.styles.ts": {
+    "styles": {
+      "useRootStyles": {
+        "base": {
+          "tokens": [],
+          "nested": {
+            "[`& .${compoundButtonClassNames.secondaryContent}`]": {
+              "tokens": [
+                {
+                  "property": "color",
+                  "token": "tokens.colorNeutralForeground2",
+                  "path": []
+                }
+              ]
+            },
+            "':hover'": {
+              "tokens": [
+                {
+                  "property": "color",
+                  "token": "tokens.colorNeutralForeground2Hover",
+                  "path": []
+                }
+              ]
+            },
+            "':hover:active'": {
+              "tokens": [
+                {
+                  "property": "color",
+                  "token": "tokens.colorNeutralForeground2Pressed",
+                  "path": []
+                }
+              ]
+            }
+          },
+          "assignedVariables": [
+            "rootStyles"
+          ]
+        },
+        "primary": {
+          "tokens": [],
+          "nested": {
+            "[`& .${compoundButtonClassNames.secondaryContent}`]": {
+              "tokens": [
+                {
+                  "property": "color",
+                  "token": "tokens.colorNeutralForegroundOnBrand",
+                  "path": []
+                }
+              ]
+            },
+            "':hover'": {
+              "tokens": [
+                {
+                  "property": "color",
+                  "token": "tokens.colorNeutralForegroundOnBrand",
+                  "path": []
+                }
+              ]
+            },
+            "':hover:active'": {
+              "tokens": [
+                {
+                  "property": "color",
+                  "token": "tokens.colorNeutralForegroundOnBrand",
+                  "path": []
+                }
+              ]
+            }
+          },
+          "assignedVariables": [
+            "rootStyles"
+          ]
+        },
+        "subtle": {
+          "tokens": [],
+          "nested": {
+            "[`& .${compoundButtonClassNames.secondaryContent}`]": {
+              "tokens": [
+                {
+                  "property": "color",
+                  "token": "tokens.colorNeutralForeground2",
+                  "path": []
+                }
+              ]
+            },
+            "':hover'": {
+              "tokens": [
+                {
+                  "property": "color",
+                  "token": "tokens.colorNeutralForeground2Hover",
+                  "path": []
+                }
+              ]
+            },
+            "':hover:active'": {
+              "tokens": [
+                {
+                  "property": "color",
+                  "token": "tokens.colorNeutralForeground2Pressed",
+                  "path": []
+                }
+              ]
+            }
+          },
+          "assignedVariables": [
+            "rootStyles"
+          ]
+        },
+        "transparent": {
+          "tokens": [],
+          "nested": {
+            "[`& .${compoundButtonClassNames.secondaryContent}`]": {
+              "tokens": [
+                {
+                  "property": "color",
+                  "token": "tokens.colorNeutralForeground2",
+                  "path": []
+                }
+              ]
+            },
+            "':hover'": {
+              "tokens": [
+                {
+                  "property": "color",
+                  "token": "tokens.colorNeutralForeground2BrandHover",
+                  "path": []
+                }
+              ]
+            },
+            "':hover:active'": {
+              "tokens": [
+                {
+                  "property": "color",
+                  "token": "tokens.colorNeutralForeground2BrandPressed",
+                  "path": []
+                }
+              ]
+            }
+          },
+          "assignedVariables": [
+            "rootStyles"
+          ]
+        },
+        "small": {
+          "tokens": [
+            {
+              "property": "fontSize",
+              "token": "tokens.fontSizeBase300",
+              "path": [
+                "fontSize"
+              ]
+            },
+            {
+              "property": "lineHeight",
+              "token": "tokens.lineHeightBase300",
+              "path": [
+                "lineHeight"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "rootStyles"
+          ]
+        },
+        "medium": {
+          "tokens": [
+            {
+              "property": "fontSize",
+              "token": "tokens.fontSizeBase300",
+              "path": [
+                "fontSize"
+              ]
+            },
+            {
+              "property": "lineHeight",
+              "token": "tokens.lineHeightBase300",
+              "path": [
+                "lineHeight"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "rootStyles"
+          ]
+        },
+        "large": {
+          "tokens": [
+            {
+              "property": "fontSize",
+              "token": "tokens.fontSizeBase400",
+              "path": [
+                "fontSize"
+              ]
+            },
+            {
+              "property": "lineHeight",
+              "token": "tokens.lineHeightBase400",
+              "path": [
+                "lineHeight"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "rootStyles"
+          ]
+        },
+        "disabled": {
+          "tokens": [],
+          "nested": {
+            "[`& .${compoundButtonClassNames.secondaryContent}`]": {
+              "tokens": [
+                {
+                  "property": "color",
+                  "token": "tokens.colorNeutralForegroundDisabled",
+                  "path": []
+                }
+              ]
+            },
+            "':hover'": {
+              "tokens": [
+                {
+                  "property": "color",
+                  "token": "tokens.colorNeutralForegroundDisabled",
+                  "path": []
+                }
+              ]
+            },
+            "':hover:active'": {
+              "tokens": [
+                {
+                  "property": "color",
+                  "token": "tokens.colorNeutralForegroundDisabled",
+                  "path": []
+                }
+              ]
+            }
+          },
+          "assignedVariables": [
+            "rootStyles"
+          ]
+        }
+      },
+      "useRootIconOnlyStyles": {
+        "small": {
+          "tokens": [
+            {
+              "property": "padding",
+              "token": "tokens.spacingHorizontalXS",
+              "path": [
+                "padding"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "rootIconOnlyStyles"
+          ]
+        },
+        "medium": {
+          "tokens": [
+            {
+              "property": "padding",
+              "token": "tokens.spacingHorizontalSNudge",
+              "path": [
+                "padding"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "rootIconOnlyStyles"
+          ]
+        },
+        "large": {
+          "tokens": [
+            {
+              "property": "padding",
+              "token": "tokens.spacingHorizontalS",
+              "path": [
+                "padding"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "rootIconOnlyStyles"
+          ]
+        }
+      },
+      "useIconStyles": {
+        "before": {
+          "tokens": [
+            {
+              "property": "marginRight",
+              "token": "tokens.spacingHorizontalM",
+              "path": [
+                "marginRight"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "iconStyles"
+          ]
+        },
+        "after": {
+          "tokens": [
+            {
+              "property": "marginLeft",
+              "token": "tokens.spacingHorizontalM",
+              "path": [
+                "marginLeft"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "iconStyles"
+          ]
+        }
+      },
+      "useContentContainerStyles": {},
+      "useSecondaryContentStyles": {
+        "base": {
+          "tokens": [
+            {
+              "property": "fontWeight",
+              "token": "tokens.fontWeightRegular",
+              "path": [
+                "fontWeight"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "secondaryContentStyles"
+          ]
+        },
+        "small": {
+          "tokens": [
+            {
+              "property": "fontSize",
+              "token": "tokens.fontSizeBase200",
+              "path": [
+                "fontSize"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "secondaryContentStyles"
+          ]
+        },
+        "medium": {
+          "tokens": [
+            {
+              "property": "fontSize",
+              "token": "tokens.fontSizeBase200",
+              "path": [
+                "fontSize"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "secondaryContentStyles"
+          ]
+        },
+        "large": {
+          "tokens": [
+            {
+              "property": "fontSize",
+              "token": "tokens.fontSizeBase300",
+              "path": [
+                "fontSize"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "secondaryContentStyles"
+          ]
+        }
+      }
+    },
+    "metadata": {
+      "styleConditions": {
+        "compoundButtonClassNames.root": {
+          "isBase": true,
+          "slotName": "root"
+        },
+        "rootStyles.base": {
+          "isBase": true,
+          "slotName": "root"
+        },
+        "rootStyles.highContrast": {
+          "isBase": true,
+          "slotName": "root"
+        },
+        "rootStyles[size]": {
+          "isBase": true,
+          "slotName": "root"
+        },
+        "state.root.className": {
+          "isBase": true,
+          "slotName": "root"
+        },
+        "rootStyles.disabled": {
+          "conditions": [
+            "(disabled || disabledFocusable)"
+          ],
+          "slotName": "root"
+        },
+        "rootStyles.disabledHighContrast": {
+          "conditions": [
+            "(disabled || disabledFocusable)"
+          ],
+          "slotName": "root"
+        },
+        "compoundButtonClassNames.contentContainer": {
+          "isBase": true,
+          "slotName": "contentContainer"
+        },
+        "contentContainerStyles.base": {
+          "isBase": true,
+          "slotName": "contentContainer"
+        },
+        "state.contentContainer.className": {
+          "isBase": true,
+          "slotName": "contentContainer"
+        },
+        "compoundButtonClassNames.icon": {
+          "isBase": true,
+          "slotName": "icon"
+        },
+        "iconStyles.base": {
+          "isBase": true,
+          "slotName": "icon"
+        },
+        "state.icon.className": {
+          "isBase": true,
+          "slotName": "icon"
+        },
+        "compoundButtonClassNames.secondaryContent": {
+          "isBase": true,
+          "slotName": "secondaryContent"
+        },
+        "secondaryContentStyles.base": {
+          "isBase": true,
+          "slotName": "secondaryContent"
+        },
+        "secondaryContentStyles[size]": {
+          "isBase": true,
+          "slotName": "secondaryContent"
+        },
+        "state.secondaryContent.className": {
+          "isBase": true,
+          "slotName": "secondaryContent"
+        }
+      }
+    }
+  },
+  "library/src/components/MenuButton/useMenuButtonStyles.styles.ts": {
+    "styles": {
+      "useRootExpandedStyles": {
+        "outline": {
+          "tokens": [
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground1Selected",
+              "path": [
+                "color"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "rootExpandedStyles"
+          ]
+        },
+        "primary": {
+          "tokens": [
+            {
+              "property": "backgroundColor",
+              "token": "tokens.colorBrandBackgroundSelected",
+              "path": [
+                "backgroundColor"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "rootExpandedStyles"
+          ]
+        },
+        "secondary": {
+          "tokens": [
+            {
+              "property": "backgroundColor",
+              "token": "tokens.colorNeutralBackground1Selected",
+              "path": [
+                "backgroundColor"
+              ]
+            },
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground1Selected",
+              "path": [
+                "color"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "rootExpandedStyles"
+          ]
+        },
+        "subtle": {
+          "tokens": [
+            {
+              "property": "backgroundColor",
+              "token": "tokens.colorSubtleBackgroundSelected",
+              "path": [
+                "backgroundColor"
+              ]
+            },
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground2Selected",
+              "path": [
+                "color"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "rootExpandedStyles"
+          ]
+        },
+        "transparent": {
+          "tokens": [
+            {
+              "property": "backgroundColor",
+              "token": "tokens.colorTransparentBackgroundSelected",
+              "path": [
+                "backgroundColor"
+              ]
+            },
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground2BrandSelected",
+              "path": [
+                "color"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "rootExpandedStyles"
+          ]
+        }
+      },
+      "useIconExpandedStyles": {
+        "outline": {
+          "tokens": [
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground1Selected",
+              "path": [
+                "color"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "iconExpandedStyles"
+          ]
+        },
+        "secondary": {
+          "tokens": [
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground1Selected",
+              "path": [
+                "color"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "iconExpandedStyles"
+          ]
+        },
+        "subtle": {
+          "tokens": [
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground2BrandSelected",
+              "path": [
+                "color"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "iconExpandedStyles"
+          ]
+        },
+        "transparent": {
+          "tokens": [
+            {
+              "property": "color",
+              "token": "tokens.colorNeutralForeground2BrandSelected",
+              "path": [
+                "color"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "iconExpandedStyles"
+          ]
+        }
+      },
+      "useMenuIconStyles": {
+        "small": {
+          "tokens": [
+            {
+              "property": "lineHeight",
+              "token": "tokens.lineHeightBase200",
+              "path": [
+                "lineHeight"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "menuIconStyles"
+          ]
+        },
+        "medium": {
+          "tokens": [
+            {
+              "property": "lineHeight",
+              "token": "tokens.lineHeightBase200",
+              "path": [
+                "lineHeight"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "menuIconStyles"
+          ]
+        },
+        "large": {
+          "tokens": [
+            {
+              "property": "lineHeight",
+              "token": "tokens.lineHeightBase400",
+              "path": [
+                "lineHeight"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "menuIconStyles"
+          ]
+        },
+        "notIconOnly": {
+          "tokens": [
+            {
+              "property": "marginLeft",
+              "token": "tokens.spacingHorizontalXS",
+              "path": [
+                "marginLeft"
+              ]
+            }
+          ],
+          "assignedVariables": [
+            "menuIconStyles"
+          ]
+        }
+      }
+    },
+    "metadata": {
+      "styleConditions": {
+        "menuButtonClassNames.root": {
+          "isBase": true,
+          "slotName": "root"
+        },
+        "state.root.className": {
+          "isBase": true,
+          "slotName": "root"
+        },
+        "rootExpandedStyles.base": {
+          "conditions": [
+            "state.root['aria-expanded']"
+          ],
+          "slotName": "root"
+        },
+        "menuButtonClassNames.icon": {
+          "isBase": true,
+          "slotName": "icon"
+        },
+        "state.icon.className": {
+          "isBase": true,
+          "slotName": "icon"
+        },
+        "iconExpandedStyles.highContrast": {
+          "conditions": [
+            "state.root['aria-expanded'] && iconExpandedStyles[state.appearance]"
+          ],
+          "slotName": "icon"
+        },
+        "menuButtonClassNames.menuIcon": {
+          "isBase": true,
+          "slotName": "menuIcon"
+        },
+        "menuIconStyles.base": {
+          "isBase": true,
+          "slotName": "menuIcon"
+        },
+        "state.menuIcon.className": {
+          "isBase": true,
+          "slotName": "menuIcon"
+        },
+        "menuIconStyles.notIconOnly": {
+          "conditions": [
+            "!state.iconOnly"
+          ],
+          "slotName": "menuIcon"
+        }
+      }
+    }
+  },
   "library/src/components/ToggleButton/useToggleButtonStyles.styles.ts": {
     "styles": {
       "useRootCheckedStyles": {
@@ -1398,12 +1721,16 @@
             {
               "property": "backgroundColor",
               "token": "tokens.colorNeutralBackground1Selected",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             },
             {
               "property": "color",
               "token": "tokens.colorNeutralForeground1Selected",
-              "path": ["color"]
+              "path": [
+                "color"
+              ]
             }
           ],
           "nested": {
@@ -1436,14 +1763,18 @@
               ]
             }
           },
-          "assignedVariables": ["rootCheckedStyles"]
+          "assignedVariables": [
+            "rootCheckedStyles"
+          ]
         },
         "outline": {
           "tokens": [
             {
               "property": "backgroundColor",
               "token": "tokens.colorTransparentBackgroundSelected",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             }
           ],
           "nested": {
@@ -1466,19 +1797,25 @@
               ]
             }
           },
-          "assignedVariables": ["rootCheckedStyles"]
+          "assignedVariables": [
+            "rootCheckedStyles"
+          ]
         },
         "primary": {
           "tokens": [
             {
               "property": "backgroundColor",
               "token": "tokens.colorBrandBackgroundSelected",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             },
             {
               "property": "color",
               "token": "tokens.colorNeutralForegroundOnBrand",
-              "path": ["color"]
+              "path": [
+                "color"
+              ]
             }
           ],
           "nested": {
@@ -1511,19 +1848,25 @@
               ]
             }
           },
-          "assignedVariables": ["rootCheckedStyles"]
+          "assignedVariables": [
+            "rootCheckedStyles"
+          ]
         },
         "subtle": {
           "tokens": [
             {
               "property": "backgroundColor",
               "token": "tokens.colorSubtleBackgroundSelected",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             },
             {
               "property": "color",
               "token": "tokens.colorNeutralForeground2Selected",
-              "path": ["color"]
+              "path": [
+                "color"
+              ]
             }
           ],
           "nested": {
@@ -1556,19 +1899,25 @@
               ]
             }
           },
-          "assignedVariables": ["rootCheckedStyles"]
+          "assignedVariables": [
+            "rootCheckedStyles"
+          ]
         },
         "transparent": {
           "tokens": [
             {
               "property": "backgroundColor",
               "token": "tokens.colorTransparentBackgroundSelected",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             },
             {
               "property": "color",
               "token": "tokens.colorNeutralForeground2BrandSelected",
-              "path": ["color"]
+              "path": [
+                "color"
+              ]
             }
           ],
           "nested": {
@@ -1601,7 +1950,9 @@
               ]
             }
           },
-          "assignedVariables": ["rootCheckedStyles"]
+          "assignedVariables": [
+            "rootCheckedStyles"
+          ]
         }
       },
       "useRootDisabledStyles": {
@@ -1610,12 +1961,16 @@
             {
               "property": "backgroundColor",
               "token": "tokens.colorNeutralBackgroundDisabled",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             },
             {
               "property": "color",
               "token": "tokens.colorNeutralForegroundDisabled",
-              "path": ["color"]
+              "path": [
+                "color"
+              ]
             }
           ],
           "nested": {
@@ -1648,14 +2003,18 @@
               ]
             }
           },
-          "assignedVariables": ["rootDisabledStyles"]
+          "assignedVariables": [
+            "rootDisabledStyles"
+          ]
         },
         "subtle": {
           "tokens": [
             {
               "property": "backgroundColor",
               "token": "tokens.colorTransparentBackground",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             }
           ],
           "nested": {
@@ -1678,14 +2037,18 @@
               ]
             }
           },
-          "assignedVariables": ["rootDisabledStyles"]
+          "assignedVariables": [
+            "rootDisabledStyles"
+          ]
         },
         "transparent": {
           "tokens": [
             {
               "property": "backgroundColor",
               "token": "tokens.colorTransparentBackground",
-              "path": ["backgroundColor"]
+              "path": [
+                "backgroundColor"
+              ]
             }
           ],
           "nested": {
@@ -1708,7 +2071,9 @@
               ]
             }
           },
-          "assignedVariables": ["rootDisabledStyles"]
+          "assignedVariables": [
+            "rootDisabledStyles"
+          ]
         }
       },
       "useIconCheckedStyles": {
@@ -1717,10 +2082,14 @@
             {
               "property": "color",
               "token": "tokens.colorNeutralForeground2BrandSelected",
-              "path": ["color"]
+              "path": [
+                "color"
+              ]
             }
           ],
-          "assignedVariables": ["iconCheckedStyles"]
+          "assignedVariables": [
+            "iconCheckedStyles"
+          ]
         }
       },
       "usePrimaryHighContrastStyles": {}
@@ -1736,23 +2105,33 @@
           "slotName": "root"
         },
         "primaryHighContrastStyles.base": {
-          "conditions": ["appearance === 'primary'"],
+          "conditions": [
+            "appearance === 'primary'"
+          ],
           "slotName": "root"
         },
         "primaryHighContrastStyles.disabled": {
-          "conditions": ["appearance === 'primary' && (disabled || disabledFocusable)"],
+          "conditions": [
+            "appearance === 'primary' && (disabled || disabledFocusable)"
+          ],
           "slotName": "root"
         },
         "rootCheckedStyles.base": {
-          "conditions": ["checked"],
+          "conditions": [
+            "checked"
+          ],
           "slotName": "root"
         },
         "rootCheckedStyles.highContrast": {
-          "conditions": ["checked"],
+          "conditions": [
+            "checked"
+          ],
           "slotName": "root"
         },
         "rootDisabledStyles.base": {
-          "conditions": ["(disabled || disabledFocusable)"],
+          "conditions": [
+            "(disabled || disabledFocusable)"
+          ],
           "slotName": "root"
         },
         "toggleButtonClassNames.icon": {
@@ -1768,7 +2147,9 @@
           "slotName": "icon"
         },
         "iconCheckedStyles.subtleOrTransparent": {
-          "conditions": ["checked && (appearance === 'subtle' || appearance === 'transparent')"],
+          "conditions": [
+            "checked && (appearance === 'subtle' || appearance === 'transparent')"
+          ],
           "slotName": "icon"
         }
       }

--- a/packages/react-components/token-analyzer-preview/library/src/__tests__/analyzer.test.ts
+++ b/packages/react-components/token-analyzer-preview/library/src/__tests__/analyzer.test.ts
@@ -36,8 +36,9 @@ describe('Token Analyzer', () => {
 
     const { styles, metadata } = analysis;
 
+    console.log(styles);
     // Verify root styles
-    expect(styles.root.tokens).toContainEqual(
+    expect(styles.useStyles.root.tokens).toContainEqual(
       expect.objectContaining({
         property: 'color',
         token: 'tokens.colorNeutralForeground1',
@@ -45,8 +46,14 @@ describe('Token Analyzer', () => {
     );
 
     // Verify metadata for conditional styles
-    expect(metadata.styleConditions).toHaveProperty('large');
-    expect(metadata.styleConditions).toHaveProperty('disabled');
-    expect(metadata.styleConditions.large.conditions).toContain("size === 'large'");
+    expect(metadata.styleConditions['styles.large']).toEqual({
+      conditions: ["size === 'large'"],
+      slotName: 'root',
+    });
+    expect(metadata.styleConditions['styles.disabled']).toEqual({
+      conditions: ['disabled'],
+      slotName: 'root',
+    });
+    expect(metadata.styleConditions['styles.large'].conditions).toContain("size === 'large'");
   });
 });

--- a/packages/react-components/token-analyzer-preview/library/src/__tests__/sample-styles.ts
+++ b/packages/react-components/token-analyzer-preview/library/src/__tests__/sample-styles.ts
@@ -21,12 +21,14 @@ const useStyles = makeStyles({
 export const Component = () => {
   const styles = useStyles();
 
-  const className = mergeClasses(
+  const state = {root:{}}
+
+  state.root.className = mergeClasses(
     styles.root,
     size === 'large' && styles.large,
     disabled && styles.disabled
   );
 
-  return <div className={className} />;
+  return <div className={state.root.className} />;
 };
 `;

--- a/packages/react-components/token-analyzer-preview/library/src/astAnalyzer.ts
+++ b/packages/react-components/token-analyzer-preview/library/src/astAnalyzer.ts
@@ -73,8 +73,8 @@ function processStyleProperty(prop: PropertyAssignment, isResetStyles?: Boolean)
         }
       });
     } else if (Node.isCallExpression(node) && node.getExpression().getText() === 'createCustomFocusIndicatorStyle') {
-      const focus = `&[data-fui-focus-visible]`;
-      const focusWithin = `&[data-fui-focus-within]:focus-within`;
+      const focus = `:focus`;
+      const focusWithin = `:focus-within`;
       let nestedModifier = focus;
 
       const passedTokens = node.getArguments()[0];
@@ -86,9 +86,9 @@ function processStyleProperty(prop: PropertyAssignment, isResetStyles?: Boolean)
             const optionName = property.getName();
             if (optionName === 'selector') {
               const selectorType = property.getInitializer()?.getText();
-              if (selectorType === "'focus'") {
+              if (selectorType === 'focus') {
                 nestedModifier = focus;
-              } else if (selectorType === "'focus-within'") {
+              } else if (selectorType === 'focus-within') {
                 nestedModifier = focusWithin;
               }
             }

--- a/packages/react-components/token-analyzer-preview/library/src/astAnalyzer.ts
+++ b/packages/react-components/token-analyzer-preview/library/src/astAnalyzer.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import {Project, Node, SourceFile, PropertyAssignment} from 'ts-morph';
+import { Project, Node, SourceFile, PropertyAssignment } from 'ts-morph';
 import {
   TokenReference,
   StyleAnalysis,
@@ -72,15 +72,50 @@ function processStyleProperty(prop: PropertyAssignment, isResetStyles?: Boolean)
           processNode(childProp.getInitializer(), [...path, childName]);
         }
       });
-    } else if(Node.isCallExpression(node)){
+    } else if (Node.isCallExpression(node) && node.getExpression().getText() === 'createCustomFocusIndicatorStyle') {
+      const focus = `&[data-fui-focus-visible]`;
+      const focusWithin = `&[data-fui-focus-within]:focus-within`;
+      let nestedModifier = focus;
+
+      const passedTokens = node.getArguments()[0];
+      const passedOptions = node.getArguments()[1];
+
+      if (passedOptions && Node.isObjectLiteralExpression(passedOptions)) {
+        passedOptions.getProperties().forEach(property => {
+          if (Node.isPropertyAssignment(property)) {
+            const optionName = property.getName();
+            if (optionName === 'selector') {
+              const selectorType = property.getInitializer()?.getText();
+              if (selectorType === "'focus'") {
+                nestedModifier = focus;
+              } else if (selectorType === "'focus-within'") {
+                nestedModifier = focusWithin;
+              }
+            }
+          }
+        });
+      }
+
+      if (passedTokens && Node.isObjectLiteralExpression(passedTokens)) {
+        passedTokens.getProperties().forEach(property => {
+          if (Node.isPropertyAssignment(property)) {
+            const childName = property.getName();
+            console.log('Get child name:', childName);
+            processNode(property.getInitializer(), [...path, nestedModifier, childName]);
+          }
+        });
+      }
+    } else if (Node.isCallExpression(node)) {
+      // Generic handling of functions that are not whitelisted - stored passed tokens under function name
+      const functionName = node.getExpression().getText();
       node.getArguments().forEach(argument => {
-        if(Node.isObjectLiteralExpression(argument)) {
+        if (Node.isObjectLiteralExpression(argument)) {
           argument.getProperties().forEach(property => {
             if (Node.isPropertyAssignment(property)) {
               const childName = property.getName();
-              processNode(property.getInitializer(), [...path, childName]);
+              processNode(property.getInitializer(), [...path, functionName, childName]);
             }
-          })
+          });
         }
       });
     }


### PR DESCRIPTION
## Previous Behavior
createCustomFocusIndicator was being applied to root styles, but should only affect focus.

## New Behavior
Whitelisted createCustomFocusIndicator to apply nested focus styles based on classname
Set generic functions to be stored under their function name, so we can resolve/lookup/handle separately later.